### PR TITLE
Make _has_changed optional as it is no longer used in django >= 1.6.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,7 @@
 Version 1.0.8 (dev)
 -------------------
 
+* ``_has_changed`` is no longer used in django >= 1.6.0
 * Use ``long()`` for ID's, not ``int()``.
 
 

--- a/any_urlfield/forms/widgets.py
+++ b/any_urlfield/forms/widgets.py
@@ -102,11 +102,11 @@ class AnyUrlWidget(widgets.MultiWidget):
 
         return result
 
-
-    def _has_changed(self, initial, data):
-        if initial is None:
-            initial = [u'http', u'', u'', u'']
-        return super(AnyUrlWidget, self)._has_changed(initial, data)
+    if django.VERSION < (1, 6, 0):
+        def _has_changed(self, initial, data):
+            if initial is None:
+                initial = [u'http', u'', u'', u'']
+            return super(AnyUrlWidget, self)._has_changed(initial, data)
 
 
     def format_output(self, rendered_widgets):


### PR DESCRIPTION
see https://github.com/brutasse/django-floppyforms/issues/82
