### PR TITLE
Ensure that all external URL prefixes are mapped to the 'http' type

### DIFF
--- a/any_urlfield/models/values.py
+++ b/any_urlfield/models/values.py
@@ -68,7 +68,13 @@ class AnyUrlValue(StrAndUnicode):
 
         url_type = url_type_registry[prefix]
         if url_type is None:
-            raise ValueError("Unsupported URL prefix in database value '{0}'.".format(url))
+            # the prefix is not in the registry, we now need to check if the
+            # prefix is an external URL prefix and if so set the url_type to
+            # the 'http' built in entry
+            if url_type_registry.is_external_url_prefix(prefix):
+                url_type = url_type_registry['http']
+            else:
+                raise ValueError("Unsupported URL prefix in database value '{0}'.".format(url))
 
         if url_type.has_id_value:
             if url_rest == 'None':

--- a/any_urlfield/registry.py
+++ b/any_urlfield/registry.py
@@ -58,7 +58,7 @@ class UrlTypeRegistry(object):
         if not title:
             title = ModelClass._meta.verbose_name
 
-        if prefix in _invalid_prefixes:
+        if self.is_external_url_prefix(prefix):
             raise ValueError("Invalid prefix value: '{0}'.".format(prefix))
         if self[prefix] is not None:
             raise ValueError("Prefix is already registered: '{0}'".format(prefix))
@@ -69,6 +69,9 @@ class UrlTypeRegistry(object):
             UrlType(ModelClass, form_field, widget, title, prefix, has_id_value)
         )
 
+
+    def is_external_url_prefix(self, prefix):
+        return prefix in _invalid_prefixes
 
     # Accessing API is similar to `list` and '`dict`:
 


### PR DESCRIPTION
We found that while the code suggested that both 'http' & 'https' should be valid external URLs that this wasn't the case. Adding a URL with an `https://` prefix would result in the following traceback:

<pre>
Environment:


Request Method: GET
Request URL: http://10.15.66.138:8000/admin/homepage/homepageitem/

Django Version: 1.5.5
Python Version: 2.7.3
Installed Applications:
('grappelli.dashboard',
 'grappelli',
 'filebrowser',
 'django.contrib.auth',
 'django.contrib.contenttypes',
 'django.contrib.sessions',
 'django.contrib.sites',
 'django.contrib.messages',
 'django.contrib.staticfiles',
 'django.contrib.admin',
 'django.contrib.sitemaps',
 'django.contrib.humanize',
 'south',
 'tinymce',
 'compressor',
 'haystack',
 'smart_selects',
 'form_designer',
 'form_designer.contrib.tinymce_plugin',
 'ganalytics',
 'any_urlfield',
 'fluent_pages',
 'fluent_pages.pagetypes.redirectnode',
 'mptt',
 'polymorphic',
 'polymorphic_tree',
 'pages',
 'pages.pagetypes.translatable',
 'luminato.foundation-theme',
 'festival',
 'myfestival',
 'festival_search',
 'press',
 'utils',
 'homepage',
 'hospitality',
 'allauth',
 'allauth.account',
 'allauth.socialaccount',
 'blogs',
 'articles',
 'allauth.socialaccount.providers.twitter',
 'gunicorn')
Installed Middleware:
('homepage.middleware.ShortCodeMiddleware',
 'django.middleware.locale.LocaleMiddleware',
 'django.middleware.common.CommonMiddleware',
 'django.contrib.sessions.middleware.SessionMiddleware',
 'django.middleware.csrf.CsrfViewMiddleware',
 'django.contrib.auth.middleware.AuthenticationMiddleware',
 'django.contrib.messages.middleware.MessageMiddleware',
 'django.middleware.clickjacking.XFrameOptionsMiddleware',
 'utils.middleware.ManualLanguageMiddleware')


Template error:
In template /home/vagrant/.virtualenvs/luminato/local/lib/python2.7/site-packages/grappelli/templates/admin/change_list.html, error at line 222
   Unsupported URL prefix in database value 'https://vimeo.com/81616727'.
   212 :                     {% blocktrans count cl.formset.errors|length as counter %}Please correct the error below.{% plural %}Please correct the errors below.{% endblocktrans %}


   213 :                 </p>


   214 :                 {{ cl.formset.non_form_errors }}


   215 :             {% endif %}


   216 :             <!-- MANAGEMENT FORM -->


   217 :             {% if cl.formset %}


   218 :                 {{ cl.formset.management_form }}


   219 :             {% endif %}


   220 :             <!-- CHANGELIST-RESULTS -->


   221 :             {% block result_list %}


   222 :                  {% result_list cl %} 


   223 :             {% endblock %}


   224 :         </section>


   225 :         <!-- PAGINATION BOTTOM -->


   226 :         {% if not cl.result_count == 0 %}


   227 :             {% block pagination_bottom %}


   228 :                 <div class="grp-module">


   229 :                     <div class="grp-row">{% pagination cl %}</div>


   230 :                 </div>


   231 :             {% endblock %}


   232 :         {% endif %}


Traceback:
File "/home/vagrant/.virtualenvs/luminato/local/lib/python2.7/site-packages/django/core/handlers/base.py" in get_response
  140.                     response = response.render()
File "/home/vagrant/.virtualenvs/luminato/local/lib/python2.7/site-packages/django/template/response.py" in render
  105.             self.content = self.rendered_content
File "/home/vagrant/.virtualenvs/luminato/local/lib/python2.7/site-packages/django/template/response.py" in rendered_content
  82.         content = template.render(context)
File "/home/vagrant/.virtualenvs/luminato/local/lib/python2.7/site-packages/django/template/base.py" in render
  140.             return self._render(context)
File "/home/vagrant/.virtualenvs/luminato/local/lib/python2.7/site-packages/django/template/base.py" in _render
  134.         return self.nodelist.render(context)
File "/home/vagrant/.virtualenvs/luminato/local/lib/python2.7/site-packages/django/template/base.py" in render
  830.                 bit = self.render_node(node, context)
File "/home/vagrant/.virtualenvs/luminato/local/lib/python2.7/site-packages/django/template/debug.py" in render_node
  74.             return node.render(context)
File "/home/vagrant/.virtualenvs/luminato/local/lib/python2.7/site-packages/django/template/loader_tags.py" in render
  124.         return compiled_parent._render(context)
File "/home/vagrant/.virtualenvs/luminato/local/lib/python2.7/site-packages/django/template/base.py" in _render
  134.         return self.nodelist.render(context)
File "/home/vagrant/.virtualenvs/luminato/local/lib/python2.7/site-packages/django/template/base.py" in render
  830.                 bit = self.render_node(node, context)
File "/home/vagrant/.virtualenvs/luminato/local/lib/python2.7/site-packages/django/template/debug.py" in render_node
  74.             return node.render(context)
File "/home/vagrant/.virtualenvs/luminato/local/lib/python2.7/site-packages/django/template/loader_tags.py" in render
  124.         return compiled_parent._render(context)
File "/home/vagrant/.virtualenvs/luminato/local/lib/python2.7/site-packages/django/template/base.py" in _render
  134.         return self.nodelist.render(context)
File "/home/vagrant/.virtualenvs/luminato/local/lib/python2.7/site-packages/django/template/base.py" in render
  830.                 bit = self.render_node(node, context)
File "/home/vagrant/.virtualenvs/luminato/local/lib/python2.7/site-packages/django/template/debug.py" in render_node
  74.             return node.render(context)
File "/home/vagrant/.virtualenvs/luminato/local/lib/python2.7/site-packages/django/template/loader_tags.py" in render
  63.             result = block.nodelist.render(context)
File "/home/vagrant/.virtualenvs/luminato/local/lib/python2.7/site-packages/django/template/base.py" in render
  830.                 bit = self.render_node(node, context)
File "/home/vagrant/.virtualenvs/luminato/local/lib/python2.7/site-packages/django/template/debug.py" in render_node
  74.             return node.render(context)
File "/home/vagrant/.virtualenvs/luminato/local/lib/python2.7/site-packages/django/template/loader_tags.py" in render
  63.             result = block.nodelist.render(context)
File "/home/vagrant/.virtualenvs/luminato/local/lib/python2.7/site-packages/django/template/base.py" in render
  830.                 bit = self.render_node(node, context)
File "/home/vagrant/.virtualenvs/luminato/local/lib/python2.7/site-packages/django/template/debug.py" in render_node
  74.             return node.render(context)
File "/home/vagrant/.virtualenvs/luminato/local/lib/python2.7/site-packages/django/template/base.py" in render
  1185.                     _dict = func(*resolved_args, **resolved_kwargs)
File "/home/vagrant/.virtualenvs/luminato/local/lib/python2.7/site-packages/django/contrib/admin/templatetags/admin_list.py" in result_list
  286.             'results': list(results(cl))}
File "/home/vagrant/.virtualenvs/luminato/local/lib/python2.7/site-packages/django/contrib/admin/templatetags/admin_list.py" in results
  264.             yield ResultList(None, items_for_result(cl, res, None))
File "/home/vagrant/.virtualenvs/luminato/local/lib/python2.7/site-packages/django/contrib/admin/templatetags/admin_list.py" in __init__
  256.         super(ResultList, self).__init__(*items)
File "/home/vagrant/.virtualenvs/luminato/local/lib/python2.7/site-packages/django/contrib/admin/templatetags/admin_list.py" in items_for_result
  184.             f, attr, value = lookup_field(field_name, result, cl.model_admin)
File "/home/vagrant/.virtualenvs/luminato/local/lib/python2.7/site-packages/django/contrib/admin/util.py" in lookup_field
  256.             attr = getattr(obj, name)
File "/project/luminato/homepage/models.py" in item_class
  119.         return self.get_real_instance().__class__.__name__
File "/home/vagrant/.virtualenvs/luminato/local/lib/python2.7/site-packages/polymorphic/polymorphic_model.py" in get_real_instance
  130.         return real_model.objects.get(pk=self.pk)
File "/home/vagrant/.virtualenvs/luminato/local/lib/python2.7/site-packages/django/db/models/manager.py" in get
  143.         return self.get_query_set().get(*args, **kwargs)
File "/home/vagrant/.virtualenvs/luminato/local/lib/python2.7/site-packages/django/db/models/query.py" in get
  398.         num = len(clone)
File "/home/vagrant/.virtualenvs/luminato/local/lib/python2.7/site-packages/django/db/models/query.py" in __len__
  106.                 self._result_cache = list(self.iterator())
File "/home/vagrant/.virtualenvs/luminato/local/lib/python2.7/site-packages/polymorphic/query.py" in iterator
  273.                     o = next(base_iter)
File "/home/vagrant/.virtualenvs/luminato/local/lib/python2.7/site-packages/django/db/models/query.py" in iterator
  327.                     obj = model(*row_data)
File "/home/vagrant/.virtualenvs/luminato/local/lib/python2.7/site-packages/polymorphic/polymorphic_model.py" in __init__
  151.         super(PolymorphicModel, self).__init__(*args, ** kwargs)
File "/home/vagrant/.virtualenvs/luminato/local/lib/python2.7/site-packages/django/db/models/base.py" in __init__
  348.                 setattr(self, field.attname, val)
File "/home/vagrant/.virtualenvs/luminato/local/lib/python2.7/site-packages/django/db/models/fields/subclassing.py" in __set__
  35.         obj.__dict__[self.field.name] = self.field.to_python(value)
File "/home/vagrant/.virtualenvs/luminato/local/lib/python2.7/site-packages/any_urlfield/models/fields.py" in to_python
  92.         return AnyUrlValue.from_db_value(value, self._static_registry)
File "/home/vagrant/.virtualenvs/luminato/local/lib/python2.7/site-packages/any_urlfield/models/values.py" in from_db_value
  67.             raise ValueError("Unsupported URL prefix in database value '{0}'.".format(url))

Exception Type: ValueError at /admin/homepage/homepageitem/
Exception Value: Unsupported URL prefix in database value 'https://vimeo.com/81616727'.
</pre>


This fix ensures that any prefix listed in the `_invalid_prefixes` list be treated as an external URL.
