### PR TITLE
Extend the URL Validator to accept more URL schemes by default

### DIFF
--- a/any_urlfield/__init__.py
+++ b/any_urlfield/__init__.py
@@ -1,2 +1,5 @@
 # following PEP 440
 __version__ = "2.2.1"
+
+# Values starting with such prefix should be handled as external URL.
+EXTERNAL_SCHEMES = ('http', 'https', 'ftp', 'ftps', 'sftp', 'webdav', 'webdavs', 'afp', 'smb', 'git', 'svn', 'hg', 'mailto', 'tel')

--- a/any_urlfield/models/fields.py
+++ b/any_urlfield/models/fields.py
@@ -2,9 +2,9 @@
 Custom model fields to link to CMS content.
 """
 import django
+from any_urlfield.forms.fields import ExtendedURLValidator
 from django.utils import six
 from django.core.exceptions import ValidationError
-from django.core.validators import URLValidator
 from django.db import models
 from any_urlfield.models.values import AnyUrlValue
 from any_urlfield.registry import UrlTypeRegistry
@@ -130,7 +130,7 @@ class AnyUrlField(base_class):
         super(AnyUrlField, self).validate(value, model_instance)
         if value:
             if value.type_prefix == 'http':
-                validate_url = URLValidator()
+                validate_url = ExtendedURLValidator()
                 validate_url(value.type_value)
             elif value.type_value:
                 if not value.exists():

--- a/any_urlfield/registry.py
+++ b/any_urlfield/registry.py
@@ -1,14 +1,10 @@
-from types import LambdaType
+from any_urlfield import EXTERNAL_SCHEMES
+from any_urlfield.forms.fields import ExtendedURLField
 from django import forms
 from django.core.cache import cache
 from django.db.models import signals
 from django.utils.translation import ugettext_lazy as _
 from any_urlfield.cache import get_object_cache_keys
-
-
-# Avoid using common protocol names as prefix, this could clash in the future.
-# Values starting with such prefix should be handled as external URL.
-_invalid_prefixes = ('http', 'https', 'ftp', 'ftps', 'sftp', 'webdav', 'webdavs', 'afp', 'smb', 'git', 'svn', 'hg')
 
 
 class UrlType(object):
@@ -84,7 +80,7 @@ class UrlTypeRegistry(object):
     def __init__(self):
         self._url_types = [UrlType(
             model=None,
-            form_field=forms.URLField(label=_("External URL"), widget=forms.TextInput(attrs={'class': 'vTextField'})),
+            form_field=ExtendedURLField(label=_("External URL"), widget=forms.TextInput(attrs={'class': 'vTextField'})),
             widget=None,
             title=_("External URL"),
             prefix='http',   # no https needed, 'http' is a special constant.
@@ -123,7 +119,7 @@ class UrlTypeRegistry(object):
         return urltype
 
     def is_external_url_prefix(self, prefix):
-        return prefix in _invalid_prefixes
+        return prefix in EXTERNAL_SCHEMES
 
     def __eq__(self, other):
         # For __getstate__ logic


### PR DESCRIPTION
specifically mailto: and tel: URLs (which are cleaned by django to have //, which works in browsers). Re #14 
